### PR TITLE
prototype: refinePose (LM) 実装と single_view ページ追加

### DIFF
--- a/assets/main.d.ts
+++ b/assets/main.d.ts
@@ -51,6 +51,7 @@ export type Module = {
     max_iteration_count: number
   ) => Result<Pose>,
   getPose: (intrinsic: Intrinsic, points_2d: Float64Array, points_3d: Float64Array) => Result<Pose>,
+  refinePose: (intrinsic: Intrinsic, points_2d: Float64Array, points_3d: Float64Array, initial_pose: Pose, max_iterations: number, dof_mask: number) => Result<Pose>,
   triangulation: (cam1: Camera, cam1_points: Float64Array, cam2: Camera, cam2_points: Float64Array) => Result<Float64Array>,
   bundleAdjustment: (scene: Scene) => Result<Scene>,
 };

--- a/docs/refine_pose.md
+++ b/docs/refine_pose.md
@@ -1,0 +1,149 @@
+# refinePose — カメラ姿勢の非線形最適化
+
+`refinePose` は、初期姿勢 $(R_0, t_0)$ から出発し、再投影誤差を最小化することでカメラ姿勢を精密化する関数である。
+最適化には **Levenberg-Marquardt (LM) 法** を用い、カメラフレームでのパラメータ化により自由度 (DOF) のマスクを実現している。
+
+## 1. ピンホールカメラモデル
+
+ワールド座標 $P_w \in \mathbb{R}^3$ をカメラ座標系に変換し、画像平面に投影する。
+
+$$
+P_c = R P_w + t
+$$
+
+ここで $R \in SO(3)$ は回転行列、$t = -RC$（$C$ はカメラ中心のワールド座標）は並進ベクトルである。
+
+カメラ座標 $P_c = (X, Y, Z)^T$ の画像への投影は
+
+$$
+u = f \frac{X}{Z} + c_x, \qquad v = f \frac{Y}{Z} + c_y
+$$
+
+で与えられる。$f$ は焦点距離、$(c_x, c_y)$ は主点である。
+
+## 2. 最適化問題
+
+$N$ 組の 3D-2D 対応 $\{(P_i, p_i)\}_{i=1}^N$ が与えられたとき、再投影誤差の二乗和を最小化する：
+
+$$
+\min_{R, t} \sum_{i=1}^{N} \left\| \pi(R P_i + t) - p_i \right\|^2
+$$
+
+ここで $\pi$ はピンホール投影関数である。
+
+## 3. カメラフレームのパラメータ化
+
+姿勢の更新をカメラ座標系で定義する。更新パラメータ $\delta = (\delta\omega, \delta t) \in \mathbb{R}^6$ に対して
+
+$$
+R_{\text{new}} = \Delta R \cdot R, \qquad t_{\text{new}} = \Delta R \cdot t + \delta t
+$$
+
+と更新する。$\Delta R = \text{rodrigues}(\delta\omega)$ は回転の微小更新である。
+
+この定式化のポイントは、更新がすべてカメラ座標系で記述されるため、各パラメータが画像上の変化と直感的に対応することである。例えば $\delta t_x$ は画像上の水平移動、$\delta\omega_z$ は画像面内の回転に対応する。
+
+## 4. Rodrigues の回転公式
+
+3 次元ベクトル $\omega \in \mathbb{R}^3$ から回転行列への変換：
+
+$$
+R(\omega) = I + \sin\theta \cdot K + (1 - \cos\theta) K^2
+$$
+
+ここで $\theta = \|\omega\|$ は回転角、$k = \omega / \theta$ は回転軸の単位ベクトル、$K = [k]_\times$ は歪対称行列：
+
+$$
+K = \begin{pmatrix} 0 & -k_z & k_y \\ k_z & 0 & -k_x \\ -k_y & k_x & 0 \end{pmatrix}
+$$
+
+$\theta \to 0$ では $R \to I$（恒等行列）に退化する。
+
+## 5. ヤコビアンの導出
+
+残差 $r_i = \pi(P_{c,i}) - p_i$ の更新パラメータ $\delta = (\delta\omega, \delta t)$ に対するヤコビアンは、連鎖律により次のように分解される：
+
+$$
+J_i = \frac{\partial r_i}{\partial \delta} = \frac{\partial \pi}{\partial P_c} \cdot \frac{\partial P_c}{\partial \delta}
+$$
+
+### 5.1 投影のヤコビアン
+
+$\pi(P_c) = \left( f\frac{X}{Z} + c_x,\ f\frac{Y}{Z} + c_y \right)$ に対して
+
+$$
+\frac{\partial \pi}{\partial P_c} = \begin{pmatrix} \frac{f}{Z} & 0 & -\frac{fX}{Z^2} \\ 0 & \frac{f}{Z} & -\frac{fY}{Z^2} \end{pmatrix}
+$$
+
+### 5.2 カメラ座標の回転に対する微分
+
+カメラフレーム更新 $P_c' = \Delta R \cdot P_c$ を $\delta\omega$ で微分する。$\delta\omega \to 0$ の近傍では
+
+$$
+P_c' \approx (I + [\delta\omega]_\times) P_c = P_c + \delta\omega \times P_c
+$$
+
+であるから
+
+$$
+\frac{\partial P_c}{\partial \delta\omega} = -[P_c]_\times = \begin{pmatrix} 0 & Z & -Y \\ -Z & 0 & X \\ Y & -X & 0 \end{pmatrix}
+$$
+
+（外積 $\delta\omega \times P_c = -[P_c]_\times \delta\omega = [P_c]_\times^T \delta\omega$ の関係を利用）
+
+### 5.3 並進に対する微分
+
+$P_c' = P_c + \delta t$ より
+
+$$
+\frac{\partial P_c}{\partial \delta t} = I_{3 \times 3}
+$$
+
+### 5.4 完全なヤコビアン
+
+以上をまとめると、各点 $i$ に対する $2 \times 6$ ヤコビアンは
+
+$$
+J_i = \frac{\partial \pi}{\partial P_c} \begin{pmatrix} [P_c]_\times^T & I \end{pmatrix}
+$$
+
+パラメータの並び順は $(\delta\omega_x, \delta\omega_y, \delta\omega_z, \delta t_x, \delta t_y, \delta t_z)$ である。
+
+## 6. Levenberg-Marquardt 法
+
+全残差ベクトル $r \in \mathbb{R}^{2N}$ と全ヤコビアン $J \in \mathbb{R}^{2N \times d}$（$d$ は有効自由度数）を構築し、以下の正規方程式を解く：
+
+$$
+\left( J^T J + \lambda \cdot \text{diag}(J^T J) \right) \delta = -J^T r
+$$
+
+- $\lambda$ が小さいとき：ガウス-ニュートン法に近づき、二次収束が期待できる
+- $\lambda$ が大きいとき：最急降下法に近づき、安定だが収束は遅い
+
+更新後のコスト $\|r_{\text{new}}\|^2$ を評価し、コストが減少すれば更新を採用して $\lambda$ を $1/10$ に、増加すれば棄却して $\lambda$ を $10$ 倍する。$\lambda$ は $[10^{-10}, 10^{10}]$ にクランプされる。
+
+## 7. 自由度マスク (DOF Mask)
+
+6 ビットのマスクで最適化する自由度を選択する。ビットは上位から
+
+| bit5 | bit4 | bit3 | bit2 | bit1 | bit0 |
+|:----:|:----:|:----:|:----:|:----:|:----:|
+| $t_x$ | $t_y$ | $t_z$ | $\omega_x$ | $\omega_y$ | $\omega_z$ |
+
+と対応する。
+
+実装では、完全な $2 \times 6$ ヤコビアンからマスクに対応する列のみを抽出して縮約ヤコビアン $J \in \mathbb{R}^{2N \times d}$ を構成する。$\delta$ もマスクされた成分のみ計算し、残りの成分はゼロのままにすることで、選択されていない自由度は一切変化しない。
+
+### 利用例
+
+| 条件点数 | マスク | 有効自由度 | 意味 |
+|:---:|:---:|:---|:---|
+| 1 | `0b110000` | $t_x, t_y$ | 画像面内の平行移動のみ |
+| 2 | `0b111001` | $t_x, t_y, t_z, \omega_z$ | 平行移動 + 奥行き + 画面内回転 |
+| 3+ | `0b111111` | 全 6 自由度 | 完全な姿勢推定 |
+
+## 8. 収束条件と安全対策
+
+- **収束判定**: $\|\delta\| < 10^{-10}$ でパラメータが十分小さくなれば打ち切り
+- **最大反復**: 既定は 20 回
+- **カメラ背面ガード**: $Z_c \le 0$ の点が存在した場合、反復を中断して現在の最良解を返す

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -353,7 +353,7 @@
     "node_modules/wasmMVG": {
       "version": "0.0.0",
       "resolved": "file:../build/wasm/RELEASE/wasmMVG-0.0.0.tgz",
-      "integrity": "sha512-z61RT3lL2D3YOj4RpqHh3pgPj4nCF2fwgEYfepcuMmDDP5ACxUGUcjGpp9XT2+vQPDRq+89VPJDgRpgyQ8LgLw==",
+      "integrity": "sha512-VdagQR70QmcrW3yt5okF5/v0SssFsO62tn8GNbMKawwM11PRgK1U1nCw/iSTCtlALzweKDuu1mzZMt/o2nASXQ==",
       "license": "ISC"
     }
   }

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -16,278 +16,16 @@
         "vite": "^8.0.12"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -295,60 +33,7 @@
       "license": "MIT",
       "optional": true,
       "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
+        "linux"
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -356,26 +41,11 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/node": {
       "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -384,8 +54,6 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -394,8 +62,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -410,25 +76,8 @@
         }
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -455,122 +104,12 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -586,80 +125,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -667,28 +132,7 @@
       "license": "MPL-2.0",
       "optional": true,
       "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -700,8 +144,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -719,15 +161,11 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -739,8 +177,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -768,8 +204,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -802,8 +236,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -812,8 +244,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -827,18 +257,8 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -851,15 +271,11 @@
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -937,7 +353,7 @@
     "node_modules/wasmMVG": {
       "version": "0.0.0",
       "resolved": "file:../build/wasm/RELEASE/wasmMVG-0.0.0.tgz",
-      "integrity": "sha512-lLXX3a5WCnWH16zN76wO35rJyknEkd84phI0gZumpE1oADDb3B/BcoMfGaRKv02O0hCaZIXAin00ZUikQAQY3w==",
+      "integrity": "sha512-z61RT3lL2D3YOj4RpqHh3pgPj4nCF2fwgEYfepcuMmDDP5ACxUGUcjGpp9XT2+vQPDRq+89VPJDgRpgyQ8LgLw==",
       "license": "ISC"
     }
   }

--- a/examples/pages/single_view.html
+++ b/examples/pages/single_view.html
@@ -43,6 +43,7 @@
   </head>
   <body>
     <div id="controls">
+      <label>Model <select id="model-select"><option value="cube">Cube</option><option value="bunny">Bunny</option></select></label>
       <label>Image <input type="file" id="image-input" accept="image/*"></label>
       <label>f  <input type="range" id="f-slider"  min="100" max="3000" value="560" step="1"> <span class="value" id="f-value">560</span></label>
       <label>cx <input type="range" id="cx-slider" min="0"   max="640"  value="320" step="1"> <span class="value" id="cx-value">320</span></label>

--- a/examples/pages/single_view.html
+++ b/examples/pages/single_view.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>single view demo</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; border: 0; border-spacing: 0; }
+      body {
+        background: #E4E6E5;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100svh;
+      }
+      #controls {
+        position: fixed;
+        top: 8px;
+        left: 8px;
+        z-index: 10;
+        background: rgba(228, 230, 229, 0.92);
+        padding: 12px;
+        border-radius: 6px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-family: monospace;
+        font-size: 13px;
+      }
+      #controls label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      #controls input[type="range"] { width: 160px; }
+      #controls .value { min-width: 48px; text-align: right; }
+      canvas {
+        max-width: 100vw;
+        max-height: 100svh;
+        touch-action: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="controls">
+      <label>Image <input type="file" id="image-input" accept="image/*"></label>
+      <label>f  <input type="range" id="f-slider"  min="100" max="3000" value="560" step="1"> <span class="value" id="f-value">560</span></label>
+      <label>cx <input type="range" id="cx-slider" min="0"   max="640"  value="320" step="1"> <span class="value" id="cx-value">320</span></label>
+      <label>cy <input type="range" id="cy-slider" min="0"   max="480"  value="240" step="1"> <span class="value" id="cy-value">240</span></label>
+    </div>
+    <canvas id="preview" width="640" height="480"></canvas>
+    <script type="module" src="/src/pages/single_view.ts"></script>
+  </body>
+</html>

--- a/examples/src/pages/single_view.ts
+++ b/examples/src/pages/single_view.ts
@@ -10,24 +10,86 @@ const fDisplay = document.getElementById("f-value") as HTMLSpanElement;
 const cxDisplay = document.getElementById("cx-value") as HTMLSpanElement;
 const cyDisplay = document.getElementById("cy-value") as HTMLSpanElement;
 const imageInput = document.getElementById("image-input") as HTMLInputElement;
+const modelSelect = document.getElementById("model-select") as HTMLSelectElement;
 
-const EDGES: [number, number][] = [
-  [0, 1], [1, 2], [2, 3], [3, 0],
-  [4, 5], [5, 6], [6, 7], [7, 4],
-  [0, 4], [1, 5], [2, 6], [3, 7],
-];
+// --- Model ---
 
-const CUBE: Vec3[] = [
-  [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
-  [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1],
-];
+interface Model {
+  vertices: Vec3[];
+  faces: [number, number, number][];
+  edges: [number, number][];
+  edgeToFaces: number[][];
+}
+
+function buildModel(vertices: Vec3[], faces: [number, number, number][]): Model {
+  const edgeMap = new Map<string, { edge: [number, number]; faceIndices: number[] }>();
+  for (let fi = 0; fi < faces.length; fi++) {
+    const [a, b, c] = faces[fi];
+    for (const [u, v] of [[a, b], [b, c], [c, a]]) {
+      const key = Math.min(u, v) + "_" + Math.max(u, v);
+      const entry = edgeMap.get(key);
+      if (entry) entry.faceIndices.push(fi);
+      else edgeMap.set(key, { edge: [u, v], faceIndices: [fi] });
+    }
+  }
+  const edges: [number, number][] = [];
+  const edgeToFaces: number[][] = [];
+  for (const { edge, faceIndices } of edgeMap.values()) {
+    edges.push(edge);
+    edgeToFaces.push(faceIndices);
+  }
+  return { vertices, faces, edges, edgeToFaces };
+}
+
+const CUBE_MODEL: Model = buildModel(
+  [
+    [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+    [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1],
+  ],
+  [
+    [0, 2, 1], [0, 3, 2],
+    [4, 5, 6], [4, 6, 7],
+    [0, 1, 5], [0, 5, 4],
+    [2, 3, 7], [2, 7, 6],
+    [0, 7, 3], [0, 4, 7],
+    [1, 2, 6], [1, 6, 5],
+  ],
+);
+
+function parsePLY(text: string): Model {
+  const lines = text.split('\n');
+  let vertexCount = 0;
+  let faceCount = 0;
+  let headerEnd = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('element vertex')) vertexCount = parseInt(line.split(' ')[2]);
+    if (line.startsWith('element face')) faceCount = parseInt(line.split(' ')[2]);
+    if (line === 'end_header') { headerEnd = i + 1; break; }
+  }
+  const vertices: Vec3[] = [];
+  for (let i = 0; i < vertexCount; i++) {
+    const parts = lines[headerEnd + i].trim().split(/\s+/).map(Number);
+    vertices.push([parts[0], parts[1], parts[2]]);
+  }
+  const faces: [number, number, number][] = [];
+  for (let i = 0; i < faceCount; i++) {
+    const parts = lines[headerEnd + vertexCount + i].trim().split(/\s+/).map(Number);
+    faces.push([parts[1], parts[2], parts[3]]);
+  }
+  return buildModel(vertices, faces);
+}
+
+let bunnyModel: Model | null = null;
 
 let wasm: Module | null = null;
 let bgImage: HTMLImageElement | null = null;
 let f = 560;
 let cx = 320;
 let cy = 240;
-let targets: ([number, number] | null)[] = new Array<null>(8).fill(null);
+let model: Model = CUBE_MODEL;
+let targets: ([number, number] | null)[] = new Array<null>(model.vertices.length).fill(null);
+let vertexVisible: Uint8Array = new Uint8Array(model.vertices.length);
 
 function makeInitialPose(): Pose {
   const ay = Math.PI / 6, ax = Math.PI / 9;
@@ -45,6 +107,14 @@ function makeInitialPose(): Pose {
 
 let pose: Pose = makeInitialPose();
 
+function resetModel(m: Model): void {
+  model = m;
+  targets = new Array<null>(model.vertices.length).fill(null);
+  vertexVisible = new Uint8Array(model.vertices.length);
+  pose = makeInitialPose();
+  render();
+}
+
 // --- Projection ---
 
 function projectPoint(p: Vec3): [number, number] | null {
@@ -56,6 +126,32 @@ function projectPoint(p: Vec3): [number, number] | null {
   if (camZ <= 0) return null;
   return [f * camX / camZ + cx, f * camY / camZ + cy];
 }
+
+function updateVisibility(): void {
+  const faceVisible = model.faces.map(([a, b, c]) => {
+    const pa = projectPoint(model.vertices[a]);
+    const pb = projectPoint(model.vertices[b]);
+    const pc = projectPoint(model.vertices[c]);
+    if (!pa || !pb || !pc) return false;
+    const cross = (pb[0] - pa[0]) * (pc[1] - pa[1]) - (pb[1] - pa[1]) * (pc[0] - pa[0]);
+    return cross < 0;
+  });
+  vertexVisible = new Uint8Array(model.vertices.length);
+  for (let fi = 0; fi < model.faces.length; fi++) {
+    if (!faceVisible[fi]) continue;
+    const [a, b, c] = model.faces[fi];
+    vertexVisible[a] = vertexVisible[b] = vertexVisible[c] = 1;
+  }
+  for (let ei = 0; ei < model.edges.length; ei++) {
+    if (!model.edgeToFaces[ei].some(fi => faceVisible[fi])) {
+      edgeVisible[ei] = 0;
+    } else {
+      edgeVisible[ei] = 1;
+    }
+  }
+}
+
+let edgeVisible: Uint8Array = new Uint8Array(0);
 
 function solvePose(): void {
   if (!wasm) return;
@@ -83,9 +179,9 @@ function solvePose(): void {
     const vi = indices[i];
     pts2d[i * 2] = targets[vi]![0];
     pts2d[i * 2 + 1] = targets[vi]![1];
-    pts3d[i * 3] = CUBE[vi][0];
-    pts3d[i * 3 + 1] = CUBE[vi][1];
-    pts3d[i * 3 + 2] = CUBE[vi][2];
+    pts3d[i * 3] = model.vertices[vi][0];
+    pts3d[i * 3 + 1] = model.vertices[vi][1];
+    pts3d[i * 3 + 2] = model.vertices[vi][2];
   }
 
   const result = wasm.refinePose(intrinsic, pts2d, pts3d, pose, 20, dofMask);
@@ -114,12 +210,17 @@ function render(): void {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   if (bgImage) ctx.drawImage(bgImage, 0, 0);
 
-  // Edges (逆算座標を結ぶ)
-  ctx.strokeStyle = "#77A9B0";
-  ctx.lineWidth = 2 * s;
-  for (const [i, j] of EDGES) {
-    const p1 = projectPoint(CUBE[i]);
-    const p2 = projectPoint(CUBE[j]);
+  edgeVisible = new Uint8Array(model.edges.length);
+  updateVisibility();
+
+  // Back-face edges (半透明)
+  ctx.strokeStyle = "rgba(0, 0, 0, 0.1)";
+  ctx.lineWidth = 1 * s;
+  for (let ei = 0; ei < model.edges.length; ei++) {
+    if (edgeVisible[ei]) continue;
+    const [i, j] = model.edges[ei];
+    const p1 = projectPoint(model.vertices[i]);
+    const p2 = projectPoint(model.vertices[j]);
     if (!p1 || !p2) continue;
     ctx.beginPath();
     ctx.moveTo(p1[0], p1[1]);
@@ -127,12 +228,27 @@ function render(): void {
     ctx.stroke();
   }
 
-  // Vertices (逆算座標)
-  const r = 5 * s;
-  for (let i = 0; i < CUBE.length; i++) {
-    const p = projectPoint(CUBE[i]);
+  // Front-face edges
+  ctx.strokeStyle = "#000000";
+  for (let ei = 0; ei < model.edges.length; ei++) {
+    if (!edgeVisible[ei]) continue;
+    const [i, j] = model.edges[ei];
+    const p1 = projectPoint(model.vertices[i]);
+    const p2 = projectPoint(model.vertices[j]);
+    if (!p1 || !p2) continue;
+    ctx.beginPath();
+    ctx.moveTo(p1[0], p1[1]);
+    ctx.lineTo(p2[0], p2[1]);
+    ctx.stroke();
+  }
+
+  // Vertices (表面のみ)
+  const r = 3 * s;
+  for (let i = 0; i < model.vertices.length; i++) {
+    if (!vertexVisible[i]) continue;
+    const p = projectPoint(model.vertices[i]);
     if (!p) continue;
-    ctx.fillStyle = targets[i] ? "#FF3090" : "#77A9B0";
+    ctx.fillStyle = targets[i] ? "#FF3090" : "#000000";
     ctx.beginPath();
     ctx.arc(p[0], p[1], r, 0, Math.PI * 2);
     ctx.fill();
@@ -145,7 +261,7 @@ function render(): void {
   for (let i = 0; i < targets.length; i++) {
     const t = targets[i];
     if (!t) continue;
-    const p = projectPoint(CUBE[i]);
+    const p = projectPoint(model.vertices[i]);
     if (!p) continue;
     ctx.beginPath();
     ctx.moveTo(t[0], t[1]);
@@ -154,7 +270,7 @@ function render(): void {
   }
   ctx.setLineDash([]);
 
-  // Target crosshairs (目標座標)
+  // Target crosshairs
   const cr = 8 * s;
   const ext = 4 * s;
   ctx.strokeStyle = "#F9F098";
@@ -198,7 +314,7 @@ function findNearest(cssX: number, cssY: number, points: ([number, number] | nul
 }
 
 function projectedVertices(): ([number, number] | null)[] {
-  return CUBE.map(v => projectPoint(v));
+  return model.vertices.map((v, i) => vertexVisible[i] ? projectPoint(v) : null);
 }
 
 canvas.addEventListener("pointerdown", (e: PointerEvent) => {
@@ -224,7 +340,7 @@ canvas.addEventListener("pointermove", (e: PointerEvent) => {
   if (!isDragging && Math.hypot(e.offsetX - downX, e.offsetY - downY) > CLICK_THRESHOLD) {
     isDragging = true;
     if (!targets[activeIndex]) {
-      const p = projectPoint(CUBE[activeIndex]);
+      const p = projectPoint(model.vertices[activeIndex]);
       if (p) targets[activeIndex] = [p[0], p[1]];
     }
   }
@@ -243,7 +359,7 @@ canvas.addEventListener("pointerup", () => {
     if (targets[activeIndex]) {
       targets[activeIndex] = null;
     } else {
-      const p = projectPoint(CUBE[activeIndex]);
+      const p = projectPoint(model.vertices[activeIndex]);
       if (p) targets[activeIndex] = [p[0], p[1]];
     }
     solvePose();
@@ -313,11 +429,23 @@ imageInput.addEventListener("change", () => {
     cySlider.max = String(img.naturalHeight);
 
     syncSliders();
-    targets = new Array<null>(8).fill(null);
+    targets = new Array<null>(model.vertices.length).fill(null);
     pose = makeInitialPose();
     render();
   };
   img.src = url;
+});
+
+modelSelect.addEventListener("change", async () => {
+  if (modelSelect.value === "bunny") {
+    if (!bunnyModel) {
+      const res = await fetch("/example_images/model.ply");
+      bunnyModel = parsePLY(await res.text());
+    }
+    resetModel(bunnyModel);
+  } else {
+    resetModel(CUBE_MODEL);
+  }
 });
 
 // --- Init ---

--- a/examples/src/pages/single_view.ts
+++ b/examples/src/pages/single_view.ts
@@ -1,0 +1,326 @@
+import wasmMVG from 'wasmMVG';
+import type { Module, Pose, Vec3 } from 'wasmMVG';
+
+const canvas = document.getElementById("preview") as HTMLCanvasElement;
+const ctx = canvas.getContext("2d")!;
+const fSlider = document.getElementById("f-slider") as HTMLInputElement;
+const cxSlider = document.getElementById("cx-slider") as HTMLInputElement;
+const cySlider = document.getElementById("cy-slider") as HTMLInputElement;
+const fDisplay = document.getElementById("f-value") as HTMLSpanElement;
+const cxDisplay = document.getElementById("cx-value") as HTMLSpanElement;
+const cyDisplay = document.getElementById("cy-value") as HTMLSpanElement;
+const imageInput = document.getElementById("image-input") as HTMLInputElement;
+
+const EDGES: [number, number][] = [
+  [0, 1], [1, 2], [2, 3], [3, 0],
+  [4, 5], [5, 6], [6, 7], [7, 4],
+  [0, 4], [1, 5], [2, 6], [3, 7],
+];
+
+const CUBE: Vec3[] = [
+  [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+  [-1, -1,  1], [1, -1,  1], [1, 1,  1], [-1, 1,  1],
+];
+
+let wasm: Module | null = null;
+let bgImage: HTMLImageElement | null = null;
+let f = 560;
+let cx = 320;
+let cy = 240;
+let targets: ([number, number] | null)[] = new Array<null>(8).fill(null);
+
+function makeInitialPose(): Pose {
+  const ay = Math.PI / 6, ax = Math.PI / 9;
+  const c1 = Math.cos(ay), s1 = Math.sin(ay);
+  const c2 = Math.cos(ax), s2 = Math.sin(ax);
+  return {
+    rotation: [
+      [c1, 0, -s1],
+      [s1 * s2, c2, c1 * s2],
+      [s1 * c2, -s2, c1 * c2],
+    ],
+    translation: [0, 0, 5],
+  };
+}
+
+let pose: Pose = makeInitialPose();
+
+// --- Projection ---
+
+function projectPoint(p: Vec3): [number, number] | null {
+  const R = pose.rotation; // R[col][row] = R(row, col) (列優先)
+  const t = pose.translation;
+  const camX = R[0][0] * p[0] + R[1][0] * p[1] + R[2][0] * p[2] + t[0];
+  const camY = R[0][1] * p[0] + R[1][1] * p[1] + R[2][1] * p[2] + t[1];
+  const camZ = R[0][2] * p[0] + R[1][2] * p[1] + R[2][2] * p[2] + t[2];
+  if (camZ <= 0) return null;
+  return [f * camX / camZ + cx, f * camY / camZ + cy];
+}
+
+function solvePose(): void {
+  if (!wasm) return;
+  const indices: number[] = [];
+  for (let i = 0; i < targets.length; i++) {
+    if (targets[i]) indices.push(i);
+  }
+  if (indices.length < 1) return;
+
+  // 点数に応じてカメラフレームの自由度を制限
+  // bit0-2: 回転 (wx, wy, wz), bit3-5: 並進 (tx, ty, tz)
+  // bit0-2: 回転 (wx, wy, wz), bit3-5: 並進 (tx, ty, tz)
+  const dofMask = indices.length === 1 ? 0x18   // tx, ty のみ (スクリーン平行移動)
+               : indices.length === 2 ? 0x3C    // wz, tx, ty, tz (画面内回転 + 平行移動 + 奥行き)
+               : 0x3F;                          // 全 6 自由度
+
+  const intrinsic = {
+    type: "PINHOLE_CAMERA_RADIAL3" as const,
+    width: canvas.width, height: canvas.height,
+    focal: f, ppx: cx, ppy: cy,
+    k1: 0, k2: 0, k3: 0,
+  };
+  const pts2d = new Float64Array(indices.length * 2);
+  const pts3d = new Float64Array(indices.length * 3);
+  for (let i = 0; i < indices.length; i++) {
+    const vi = indices[i];
+    pts2d[i * 2] = targets[vi]![0];
+    pts2d[i * 2 + 1] = targets[vi]![1];
+    pts3d[i * 3] = CUBE[vi][0];
+    pts3d[i * 3 + 1] = CUBE[vi][1];
+    pts3d[i * 3 + 2] = CUBE[vi][2];
+  }
+
+  const result = wasm.refinePose(intrinsic, pts2d, pts3d, pose, 20, dofMask);
+  if (result.result === "ok") {
+    pose = result.value;
+  }
+}
+
+// --- Coordinate helpers ---
+
+function cssToCanvas(cssX: number, cssY: number): [number, number] {
+  return [
+    cssX * canvas.width / canvas.clientWidth,
+    cssY * canvas.height / canvas.clientHeight,
+  ];
+}
+
+function dScale(): number {
+  return canvas.width / canvas.clientWidth;
+}
+
+// --- Render ---
+
+function render(): void {
+  const s = dScale();
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (bgImage) ctx.drawImage(bgImage, 0, 0);
+
+  // Edges (逆算座標を結ぶ)
+  ctx.strokeStyle = "#77A9B0";
+  ctx.lineWidth = 2 * s;
+  for (const [i, j] of EDGES) {
+    const p1 = projectPoint(CUBE[i]);
+    const p2 = projectPoint(CUBE[j]);
+    if (!p1 || !p2) continue;
+    ctx.beginPath();
+    ctx.moveTo(p1[0], p1[1]);
+    ctx.lineTo(p2[0], p2[1]);
+    ctx.stroke();
+  }
+
+  // Vertices (逆算座標)
+  const r = 5 * s;
+  for (let i = 0; i < CUBE.length; i++) {
+    const p = projectPoint(CUBE[i]);
+    if (!p) continue;
+    ctx.fillStyle = targets[i] ? "#FF3090" : "#77A9B0";
+    ctx.beginPath();
+    ctx.arc(p[0], p[1], r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // 目標座標と逆算座標を結ぶ線
+  ctx.strokeStyle = "#F9F098";
+  ctx.lineWidth = 1.5 * s;
+  ctx.setLineDash([4 * s, 4 * s]);
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i];
+    if (!t) continue;
+    const p = projectPoint(CUBE[i]);
+    if (!p) continue;
+    ctx.beginPath();
+    ctx.moveTo(t[0], t[1]);
+    ctx.lineTo(p[0], p[1]);
+    ctx.stroke();
+  }
+  ctx.setLineDash([]);
+
+  // Target crosshairs (目標座標)
+  const cr = 8 * s;
+  const ext = 4 * s;
+  ctx.strokeStyle = "#F9F098";
+  ctx.lineWidth = 2 * s;
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i];
+    if (!t) continue;
+    const [tx, ty] = t;
+    ctx.beginPath();
+    ctx.arc(tx, ty, cr, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(tx - cr - ext, ty);
+    ctx.lineTo(tx + cr + ext, ty);
+    ctx.moveTo(tx, ty - cr - ext);
+    ctx.lineTo(tx, ty + cr + ext);
+    ctx.stroke();
+  }
+}
+
+// --- Interaction ---
+
+const CLICK_THRESHOLD = 4;
+let activeIndex = -1;
+let isDragging = false;
+let downX = 0;
+let downY = 0;
+
+function findNearest(cssX: number, cssY: number, points: ([number, number] | null)[]): number {
+  const [mx, my] = cssToCanvas(cssX, cssY);
+  const threshold = 14 * dScale();
+  let minDist = threshold;
+  let closest = -1;
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+    if (!p) continue;
+    const d = Math.hypot(p[0] - mx, p[1] - my);
+    if (d < minDist) { minDist = d; closest = i; }
+  }
+  return closest;
+}
+
+function projectedVertices(): ([number, number] | null)[] {
+  return CUBE.map(v => projectPoint(v));
+}
+
+canvas.addEventListener("pointerdown", (e: PointerEvent) => {
+  let idx = findNearest(e.offsetX, e.offsetY, targets);
+  if (idx < 0) idx = findNearest(e.offsetX, e.offsetY, projectedVertices());
+  if (idx >= 0) {
+    activeIndex = idx;
+    isDragging = false;
+    downX = e.offsetX;
+    downY = e.offsetY;
+    canvas.setPointerCapture(e.pointerId);
+  }
+});
+
+canvas.addEventListener("pointermove", (e: PointerEvent) => {
+  if (activeIndex < 0) {
+    const hit = findNearest(e.offsetX, e.offsetY, targets) >= 0
+      || findNearest(e.offsetX, e.offsetY, projectedVertices()) >= 0;
+    canvas.style.cursor = hit ? "pointer" : "default";
+    return;
+  }
+
+  if (!isDragging && Math.hypot(e.offsetX - downX, e.offsetY - downY) > CLICK_THRESHOLD) {
+    isDragging = true;
+    if (!targets[activeIndex]) {
+      const p = projectPoint(CUBE[activeIndex]);
+      if (p) targets[activeIndex] = [p[0], p[1]];
+    }
+  }
+
+  if (isDragging && targets[activeIndex]) {
+    const [mx, my] = cssToCanvas(e.offsetX, e.offsetY);
+    targets[activeIndex] = [mx, my];
+    solvePose();
+    canvas.style.cursor = "grabbing";
+    render();
+  }
+});
+
+canvas.addEventListener("pointerup", () => {
+  if (activeIndex >= 0 && !isDragging) {
+    if (targets[activeIndex]) {
+      targets[activeIndex] = null;
+    } else {
+      const p = projectPoint(CUBE[activeIndex]);
+      if (p) targets[activeIndex] = [p[0], p[1]];
+    }
+    solvePose();
+    render();
+  }
+  activeIndex = -1;
+  isDragging = false;
+  canvas.style.cursor = "default";
+});
+
+canvas.addEventListener("lostpointercapture", () => {
+  activeIndex = -1;
+  isDragging = false;
+  canvas.style.cursor = "default";
+  render();
+});
+
+// --- Controls ---
+
+function syncSliders(): void {
+  fSlider.value = String(Math.round(f));
+  cxSlider.value = String(Math.round(cx));
+  cySlider.value = String(Math.round(cy));
+  fDisplay.textContent = String(Math.round(f));
+  cxDisplay.textContent = String(Math.round(cx));
+  cyDisplay.textContent = String(Math.round(cy));
+}
+
+fSlider.addEventListener("input", () => {
+  f = Number(fSlider.value);
+  fDisplay.textContent = fSlider.value;
+  solvePose();
+  render();
+});
+
+cxSlider.addEventListener("input", () => {
+  cx = Number(cxSlider.value);
+  cxDisplay.textContent = cxSlider.value;
+  solvePose();
+  render();
+});
+
+cySlider.addEventListener("input", () => {
+  cy = Number(cySlider.value);
+  cyDisplay.textContent = cySlider.value;
+  solvePose();
+  render();
+});
+
+imageInput.addEventListener("change", () => {
+  const file = imageInput.files?.[0];
+  if (!file) return;
+  const img = new Image();
+  img.onload = () => {
+    bgImage = img;
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+
+    f = (img.naturalWidth + img.naturalHeight) / 2;
+    cx = img.naturalWidth / 2;
+    cy = img.naturalHeight / 2;
+
+    fSlider.max = String(Math.round(Math.max(3000, f * 3)));
+    cxSlider.max = String(img.naturalWidth);
+    cySlider.max = String(img.naturalHeight);
+
+    syncSliders();
+    targets = new Array<null>(8).fill(null);
+    pose = makeInitialPose();
+    render();
+  };
+  img.src = URL.createObjectURL(file);
+});
+
+// --- Init ---
+syncSliders();
+render();
+
+wasmMVG({ noInitialRun: true }).then(m => { wasm = m; });

--- a/examples/src/pages/single_view.ts
+++ b/examples/src/pages/single_view.ts
@@ -66,11 +66,10 @@ function solvePose(): void {
   if (indices.length < 1) return;
 
   // 点数に応じてカメラフレームの自由度を制限
-  // bit0-2: 回転 (wx, wy, wz), bit3-5: 並進 (tx, ty, tz)
-  // bit0-2: 回転 (wx, wy, wz), bit3-5: 並進 (tx, ty, tz)
-  const dofMask = indices.length === 1 ? 0x18   // tx, ty のみ (スクリーン平行移動)
-               : indices.length === 2 ? 0x3C    // wz, tx, ty, tz (画面内回転 + 平行移動 + 奥行き)
-               : 0x3F;                          // 全 6 自由度
+  //                                    tx ty tz wx wy wz
+  const dofMask = indices.length === 1 ? 0b110000  // tx, ty
+               : indices.length === 2 ? 0b111001  // tx, ty, tz, wz
+               : 0b111111;                        // 全 6 自由度
 
   const intrinsic = {
     type: "PINHOLE_CAMERA_RADIAL3" as const,
@@ -298,7 +297,9 @@ imageInput.addEventListener("change", () => {
   const file = imageInput.files?.[0];
   if (!file) return;
   const img = new Image();
+  const url = URL.createObjectURL(file);
   img.onload = () => {
+    URL.revokeObjectURL(url);
     bgImage = img;
     canvas.width = img.naturalWidth;
     canvas.height = img.naturalHeight;
@@ -316,7 +317,7 @@ imageInput.addEventListener("change", () => {
     pose = makeInitialPose();
     render();
   };
-  img.src = URL.createObjectURL(file);
+  img.src = url;
 });
 
 // --- Init ---

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@ EMSCRIPTEN_BINDINGS(wasm_mvg) {
 	emscripten::function("hello", &hello);
 	emscripten::function("getRelativePose", &getRelativePoseJs);
 	emscripten::function("getPose", &getPoseJs);
+	emscripten::function("refinePose", &refinePoseJs);
 	emscripten::function("triangulation", &triangulationJs);
 	emscripten::function("bundleAdjustment", &bundleAdjustmentJs);
 }

--- a/src/wasmMVG.cpp
+++ b/src/wasmMVG.cpp
@@ -190,9 +190,11 @@ Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, s
 	}
 
 	// 有効な自由度のインデックスを収集
+	// ビットレイアウト (上位から): tx, ty, tz, wx, wy, wz
+	static const int bit_to_param[] = {2, 1, 0, 5, 4, 3};
 	std::vector<int> active;
 	for (int i = 0; i < 6; i++) {
-		if (dof_mask & (1u << i)) active.push_back(i);
+		if (dof_mask & (1u << i)) active.push_back(bit_to_param[i]);
 	}
 	const int ndof = static_cast<int>(active.size());
 	if (ndof == 0) return initial;
@@ -215,9 +217,11 @@ Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, s
 	for (size_t iter = 0; iter < max_iterations; iter++) {
 		Eigen::VectorXd residuals(2 * n);
 		Eigen::MatrixXd J(2 * n, ndof);
+		bool has_behind = false;
 
 		for (size_t i = 0; i < n; i++) {
 			const Vec3 Pc = R * Vec3(points_3d.col(i)) + t;
+			if (Pc(2) <= 0) { has_behind = true; break; }
 			const Vec2 proj = view.intrinsic->project(Pc);
 			residuals.segment<2>(2 * i) = proj - Vec2(points_2d_undisto.col(i));
 
@@ -227,6 +231,7 @@ Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, s
 				J.block<2,1>(2 * i, j) = Ji_full.col(active[j]);
 			}
 		}
+		if (has_behind) break;
 
 		// LM 更新
 		const Eigen::MatrixXd JtJ = J.transpose() * J;
@@ -257,10 +262,10 @@ Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, s
 		if (cost_new < cost_old) {
 			R = R_new;
 			t = t_new;
-			lambda *= 0.1;
+			lambda = std::clamp(lambda * 0.1, 1e-10, 1e10);
 			if (delta_active.norm() < 1e-10) break;
 		} else {
-			lambda *= 10.0;
+			lambda = std::clamp(lambda * 10.0, 1e-10, 1e10);
 		}
 	}
 

--- a/src/wasmMVG.cpp
+++ b/src/wasmMVG.cpp
@@ -136,6 +136,137 @@ Pose3 getPose(const View &view, const Mat &points_3d) {
 	return pose;
 }
 
+// Rodrigues ベクトルから回転行列へ変換
+static openMVG::Mat3 rodrigues(const Vec3 &w) {
+	const double theta = w.norm();
+	if (theta < 1e-12) return openMVG::Mat3::Identity();
+	const Vec3 k = w / theta;
+	openMVG::Mat3 K;
+	K <<     0, -k(2),  k(1),
+	      k(2),     0, -k(0),
+	     -k(1),  k(0),     0;
+	return openMVG::Mat3::Identity() + std::sin(theta) * K + (1.0 - std::cos(theta)) * K * K;
+}
+
+// カメラフレームでの 6 自由度ヤコビアン (2×6) を計算する。
+// パラメータ順: [δwx, δwy, δwz, δtx, δty, δtz] (すべてカメラ座標系)
+// 更新則: p_cam_new = rodrigues(δw) * p_cam + δt
+static void cameraFrameJacobian(
+	const double focal, const Vec3 &Pc,
+	Eigen::Matrix<double, 2, 6> &J
+) {
+	const double X = Pc(0), Y = Pc(1), Z = Pc(2);
+	const double Zinv = 1.0 / Z;
+	const double Zinv2 = Zinv * Zinv;
+
+	// d(u,v)/d(Pc)
+	Eigen::Matrix<double, 2, 3> dproj;
+	dproj << focal * Zinv, 0,            -focal * X * Zinv2,
+	         0,            focal * Zinv,  -focal * Y * Zinv2;
+
+	// d(Pc)/d(δw) = [Pc]×  (δw × Pc の δw に対する微分)
+	Eigen::Matrix<double, 3, 3> skew;
+	skew <<  0,  Z, -Y,
+	        -Z,  0,  X,
+	         Y, -X,  0;
+
+	J.block<2,3>(0,0) = dproj * skew;  // 回転
+	J.block<2,3>(0,3) = dproj;         // 並進 (d(Pc)/d(δt) = I)
+}
+
+Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, size_t max_iterations, uint32_t dof_mask) {
+	if (view.points.rows() != 2) {
+		throw std::invalid_argument("view.points must have 2 rows.");
+	}
+	if (points_3d.rows() != 3) {
+		throw std::invalid_argument("points_3d must have 3 rows.");
+	}
+	if (view.points.cols() != points_3d.cols()) {
+		throw std::invalid_argument("view.points and points_3d must have the same number of columns.");
+	}
+	const size_t n = view.points.cols();
+	if (n < 1) {
+		throw std::invalid_argument("At least 1 point correspondence is required.");
+	}
+
+	// 有効な自由度のインデックスを収集
+	std::vector<int> active;
+	for (int i = 0; i < 6; i++) {
+		if (dof_mask & (1u << i)) active.push_back(i);
+	}
+	const int ndof = static_cast<int>(active.size());
+	if (ndof == 0) return initial;
+	if (static_cast<int>(2 * n) < ndof) {
+		throw std::invalid_argument("Not enough points for the requested DOF.");
+	}
+
+	const Mat points_2d_undisto = columnMap(view.points, [&](const Vec &p) {
+		return view.intrinsic->get_ud_pixel(p);
+	});
+
+	const std::vector<double> iparams = view.intrinsic->getParams();
+	const double focal = iparams[0];
+
+	openMVG::Mat3 R = initial.rotation();
+	Vec3 t = initial.translation();  // t = -R*C
+
+	double lambda = 1e-3;
+
+	for (size_t iter = 0; iter < max_iterations; iter++) {
+		Eigen::VectorXd residuals(2 * n);
+		Eigen::MatrixXd J(2 * n, ndof);
+
+		for (size_t i = 0; i < n; i++) {
+			const Vec3 Pc = R * Vec3(points_3d.col(i)) + t;
+			const Vec2 proj = view.intrinsic->project(Pc);
+			residuals.segment<2>(2 * i) = proj - Vec2(points_2d_undisto.col(i));
+
+			Eigen::Matrix<double, 2, 6> Ji_full;
+			cameraFrameJacobian(focal, Pc, Ji_full);
+			for (int j = 0; j < ndof; j++) {
+				J.block<2,1>(2 * i, j) = Ji_full.col(active[j]);
+			}
+		}
+
+		// LM 更新
+		const Eigen::MatrixXd JtJ = J.transpose() * J;
+		const Eigen::VectorXd Jtr = J.transpose() * residuals;
+		Eigen::MatrixXd A = JtJ;
+		A.diagonal() += lambda * JtJ.diagonal();
+		const Eigen::VectorXd delta_active = A.ldlt().solve(-Jtr);
+
+		// 6 自由度に展開
+		Eigen::Matrix<double, 6, 1> delta = Eigen::Matrix<double, 6, 1>::Zero();
+		for (int j = 0; j < ndof; j++) {
+			delta(active[j]) = delta_active(j);
+		}
+
+		// カメラフレームの更新を適用: R_new = dR * R, t_new = dR * t + dt
+		const openMVG::Mat3 dR = rodrigues(delta.head<3>());
+		const openMVG::Mat3 R_new = dR * R;
+		const Vec3 t_new = dR * t + delta.tail<3>();
+
+		double cost_old = residuals.squaredNorm();
+		double cost_new = 0.0;
+		for (size_t i = 0; i < n; i++) {
+			const Vec2 proj = view.intrinsic->project(R_new * Vec3(points_3d.col(i)) + t_new);
+			const Vec2 diff = proj - Vec2(points_2d_undisto.col(i));
+			cost_new += diff.squaredNorm();
+		}
+
+		if (cost_new < cost_old) {
+			R = R_new;
+			t = t_new;
+			lambda *= 0.1;
+			if (delta_active.norm() < 1e-10) break;
+		} else {
+			lambda *= 10.0;
+		}
+	}
+
+	return Pose3{ R, -R.transpose() * t };
+}
+
 /**
  * @brief 特徴点の三次元座標を三角測量
  * @param[in] view1 カメラ1 (内部パラメータ+姿勢) と特徴点のスクリーン座標

--- a/src/wasmMVG.h
+++ b/src/wasmMVG.h
@@ -78,6 +78,19 @@ Pose3 getPose(const View &view, const Mat &points_3d);
 Mat triangulation(const PosedView &view1, const PosedView &view2);
 
 /**
+ * @brief 初期姿勢から再投影誤差を最小化してカメラ姿勢を精密化 (LM)
+ * @param[in] view       カメラ内部パラメータと特徴点のスクリーン座標
+ * @param[in] points_3d  view.points に対応する特徴点の現実座標 (3 x N)
+ * @param[in] initial    初期姿勢
+ * @param[in] max_iterations 最大反復回数
+ * @param[in] dof_mask   カメラフレームの自由度ビットマスク (bit0-2: 回転 wx,wy,wz, bit3-5: 並進 tx,ty,tz)
+ *                        0x3F = 全6自由度, 0x30 = tx,ty のみ, 0x3C = wz,tx,ty,tz
+ * @return 精密化された姿勢
+ * @exception 引数の行列サイズが不正だった場合に std::invalid_argument が発生
+ */
+Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, size_t max_iterations = 20, uint32_t dof_mask = 0x3F);
+
+/**
  * @brief バンドル調整
  * @param[in] scene バンドル調整を行うシーン
  * @return バンドル調整後のシーン

--- a/src/wasmMVG.h
+++ b/src/wasmMVG.h
@@ -83,12 +83,12 @@ Mat triangulation(const PosedView &view1, const PosedView &view2);
  * @param[in] points_3d  view.points に対応する特徴点の現実座標 (3 x N)
  * @param[in] initial    初期姿勢
  * @param[in] max_iterations 最大反復回数
- * @param[in] dof_mask   カメラフレームの自由度ビットマスク (bit0-2: 回転 wx,wy,wz, bit3-5: 並進 tx,ty,tz)
- *                        0x3F = 全6自由度, 0x30 = tx,ty のみ, 0x3C = wz,tx,ty,tz
+ * @param[in] dof_mask   カメラフレームの自由度ビットマスク (上位から tx,ty,tz,wx,wy,wz)
+ *                        0b111111 = 全6自由度, 0b110000 = tx,ty のみ, 0b111001 = tx,ty,tz,wz
  * @return 精密化された姿勢
  * @exception 引数の行列サイズが不正だった場合に std::invalid_argument が発生
  */
-Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, size_t max_iterations = 20, uint32_t dof_mask = 0x3F);
+Pose3 refinePose(const View &view, const Mat &points_3d, const Pose3 &initial, size_t max_iterations = 20, uint32_t dof_mask = 0b111111);
 
 /**
  * @brief バンドル調整

--- a/src/wasmMVG_bindings.cpp
+++ b/src/wasmMVG_bindings.cpp
@@ -231,6 +231,22 @@ Val getPoseJs(const Val &intrinsic, const Val &points_2d, const Val &points_3d) 
 	}
 }
 
+Val refinePoseJs(const Val &intrinsic, const Val &points_2d, const Val &points_3d, const Val &initial_pose, const size_t max_iterations, const size_t dof_mask) {
+	try {
+		const Pose3 pose = refinePose(
+			View{ valToIntrinsic(intrinsic), valToPoints(points_2d, 2) },
+			valToPoints(points_3d, 3),
+			valToPose(initial_pose),
+			max_iterations,
+			static_cast<uint32_t>(dof_mask)
+		);
+		return ok(poseToVal(pose));
+	}
+	catch (const std::exception &e) {
+		return error(e.what());
+	}
+}
+
 Val triangulationJs(const Val &cam1, const Val &cam1_points, const Val &cam2, const Val &cam2_points) {
 	try {
 		Mat points_3d = triangulation(

--- a/src/wasmMVG_bindings.h
+++ b/src/wasmMVG_bindings.h
@@ -32,6 +32,7 @@ Val getRelativePoseJs(
 	const size_t max_iteration_count
 );
 Val getPoseJs(const Val &intrinsic, const Val &points_2d, const Val &points_3d);
+Val refinePoseJs(const Val &intrinsic, const Val &points_2d, const Val &points_3d, const Val &initial_pose, size_t max_iterations, size_t dof_mask);
 Val triangulationJs(const Val &cam1, const Val &cam1_points, const Val &cam2, const Val &cam2_points);
 Val bundleAdjustmentJs(const Val &scene);
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -72,6 +72,126 @@ TEST(getPose, recoversPose) {
 	EXPECT_TRUE(pose.center().isApprox(data.cam2.pose.center(), 1e-4));
 }
 
+// 初期姿勢に摂動を加えた状態から refinePose で真の姿勢を復元できることを確認
+TEST(refinePose, recoversFromPerturbedPose) {
+	const auto intrinsic = pinholeIntrinsic(640, 480, 500.0);
+	const double ay = M_PI / 6.0, ax = M_PI / 9.0;
+	openMVG::Mat3 Ry, Rx;
+	Ry << std::cos(ay), 0, std::sin(ay),
+	      0,            1, 0,
+	     -std::sin(ay), 0, std::cos(ay);
+	Rx << 1, 0,             0,
+	      0, std::cos(ax), -std::sin(ax),
+	      0, std::sin(ax),  std::cos(ax);
+	const openMVG::Mat3 R = Ry * Rx;
+	const Pose3 gt_pose(R, Vec3(0.0, 0.0, -5.0));
+	const Camera cam{ intrinsic, gt_pose };
+
+	Mat points_3d(3, 8);
+	points_3d.col(0) = Vec3(-1, -1, -1);
+	points_3d.col(1) = Vec3( 1, -1, -1);
+	points_3d.col(2) = Vec3( 1,  1, -1);
+	points_3d.col(3) = Vec3(-1,  1, -1);
+	points_3d.col(4) = Vec3(-1, -1,  1);
+	points_3d.col(5) = Vec3( 1, -1,  1);
+	points_3d.col(6) = Vec3( 1,  1,  1);
+	points_3d.col(7) = Vec3(-1,  1,  1);
+
+	const Mat points_2d = projectPoints(cam, points_3d);
+
+	// 真の姿勢に摂動を加えた初期値
+	const Pose3 perturbed(R * Eigen::AngleAxisd(0.1, Vec3::UnitY()).toRotationMatrix(),
+	                      Vec3(0.2, -0.1, -4.8));
+
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, perturbed, 50);
+	EXPECT_TRUE(recovered.rotation().isApprox(gt_pose.rotation(), 1e-6))
+		<< "rotation expected:\n" << gt_pose.rotation()
+		<< "\ngot:\n" << recovered.rotation();
+	EXPECT_TRUE(recovered.center().isApprox(gt_pose.center(), 1e-6))
+		<< "center expected: " << gt_pose.center().transpose()
+		<< " got: " << recovered.center().transpose();
+}
+
+// refinePose で少数 (4 点) でも全点が影響して姿勢が復元されることを確認
+TEST(refinePose, worksWithFourPoints) {
+	const auto intrinsic = pinholeIntrinsic(640, 480, 500.0);
+	const Pose3 gt_pose(openMVG::Mat3::Identity(), Vec3(0.0, 0.0, -5.0));
+	const Camera cam{ intrinsic, gt_pose };
+
+	Mat points_3d(3, 4);
+	points_3d.col(0) = Vec3(-1, -1, 0);
+	points_3d.col(1) = Vec3( 1, -1, 0);
+	points_3d.col(2) = Vec3( 1,  1, 0);
+	points_3d.col(3) = Vec3(-1,  1, 0);
+
+	const Mat points_2d = projectPoints(cam, points_3d);
+
+	const Pose3 perturbed(openMVG::Mat3::Identity(), Vec3(0.1, -0.1, -4.9));
+
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, perturbed, 50);
+	EXPECT_TRUE(recovered.rotation().isApprox(gt_pose.rotation(), 1e-4));
+	EXPECT_TRUE(recovered.center().isApprox(gt_pose.center(), 1e-4))
+		<< "center expected: " << gt_pose.center().transpose()
+		<< " got: " << recovered.center().transpose();
+}
+
+// 1 点 + tx,ty のみで平行移動を追従できることを確認
+TEST(refinePose, onePointTranslation) {
+	const auto intrinsic = pinholeIntrinsic(640, 480, 500.0);
+	const Pose3 gt_pose(openMVG::Mat3::Identity(), Vec3(0.3, -0.2, -5.0));
+	const Camera cam_gt{ intrinsic, gt_pose };
+
+	Mat points_3d(3, 1);
+	points_3d.col(0) = Vec3(0, 0, 0);
+	const Mat points_2d = projectPoints(cam_gt, points_3d);
+
+	// 初期姿勢はカメラ中心が少しずれている
+	const Pose3 initial(openMVG::Mat3::Identity(), Vec3(0.0, 0.0, -5.0));
+
+	// dof_mask = 0x18 (bit3=tx, bit4=ty のみ)
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 50, 0x18);
+
+	// tx, ty は目標に近づくが、tz, 回転は初期値のまま
+	const Vec3 t_recovered = recovered.translation();
+	const Vec3 t_gt = gt_pose.translation();
+	EXPECT_NEAR(t_recovered(0), t_gt(0), 1e-6);
+	EXPECT_NEAR(t_recovered(1), t_gt(1), 1e-6);
+	EXPECT_NEAR(t_recovered(2), initial.translation()(2), 1e-10);
+	EXPECT_TRUE(recovered.rotation().isApprox(openMVG::Mat3::Identity(), 1e-10));
+}
+
+// 2 点 + wz,tx,ty,tz でスケールと画面内回転を追従できることを確認
+TEST(refinePose, twoPointsScaleAndRotation) {
+	const auto intrinsic = pinholeIntrinsic(640, 480, 500.0);
+	// 画面内回転 (rz=15°) + 奥行き変更でターゲットを生成
+	const double rz = M_PI / 12.0;
+	openMVG::Mat3 Rz;
+	Rz << std::cos(rz), -std::sin(rz), 0,
+	      std::sin(rz),  std::cos(rz), 0,
+	      0,             0,            1;
+	const Pose3 gt_pose(Rz, Vec3(0.1, -0.1, -4.0));
+	const Camera cam_gt{ intrinsic, gt_pose };
+
+	Mat points_3d(3, 2);
+	points_3d.col(0) = Vec3(-1, 0, 0);
+	points_3d.col(1) = Vec3( 1, 0, 0);
+	const Mat points_2d = projectPoints(cam_gt, points_3d);
+
+	const Pose3 initial(openMVG::Mat3::Identity(), Vec3(0.0, 0.0, -5.0));
+
+	// dof_mask = 0x3C (wz, tx, ty, tz)
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 100, 0x3C);
+
+	// 再投影誤差が十分小さいことを確認
+	const Camera cam_recovered{ intrinsic, recovered };
+	for (int i = 0; i < 2; i++) {
+		const Vec2 reproj = projectPoint(cam_recovered, Vec3(points_3d.col(i)));
+		EXPECT_TRUE(reproj.isApprox(Vec2(points_2d.col(i)), 1e-3))
+			<< "point " << i << " expected: " << points_2d.col(i).transpose()
+			<< " got: " << reproj.transpose();
+	}
+}
+
 // 2 視点の対応点から相対姿勢を復元できることを確認 (並進はスケール不定)
 TEST(getRelativePose, recoversRelativePose) {
 	std::mt19937 rnd(123);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -148,8 +148,8 @@ TEST(refinePose, onePointTranslation) {
 	// 初期姿勢はカメラ中心が少しずれている
 	const Pose3 initial(openMVG::Mat3::Identity(), Vec3(0.0, 0.0, -5.0));
 
-	// dof_mask = 0x18 (bit3=tx, bit4=ty のみ)
-	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 50, 0x18);
+	// dof_mask = 0b110000 (tx, ty のみ)
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 50, 0b110000);
 
 	// tx, ty は目標に近づくが、tz, 回転は初期値のまま
 	const Vec3 t_recovered = recovered.translation();
@@ -179,8 +179,8 @@ TEST(refinePose, twoPointsScaleAndRotation) {
 
 	const Pose3 initial(openMVG::Mat3::Identity(), Vec3(0.0, 0.0, -5.0));
 
-	// dof_mask = 0x3C (wz, tx, ty, tz)
-	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 100, 0x3C);
+	// dof_mask = 0b111001 (tx, ty, tz, wz)
+	const Pose3 recovered = refinePose(View{ intrinsic, points_2d }, points_3d, initial, 100, 0b111001);
 
 	// 再投影誤差が十分小さいことを確認
 	const Camera cam_recovered{ intrinsic, recovered };


### PR DESCRIPTION
これは全部 AI に書かせた試作で、動くことを最優先に作っているので色々と雑です。
このコードは全部捨てて、あとで全部作り直す予定。

## Summary
- single_view ページを追加: 立方体ワイヤーフレーム表示、背景画像対応、目標座標のドラッグで姿勢推定
- `refinePose` を LM (Levenberg-Marquardt) でフルスクラッチ実装: 全点の再投影誤差を最小化し、RANSAC によるアウトライア除去なしで安定した姿勢推定を実現
- カメラフレームの DOF マスクにより自由度を制限可能 (1点: 平行移動, 2点: 回転+スケール, 3点以上: 全6自由度)
- `projectPoint` の回転行列添字の転置バグを修正 (列優先を行優先として読んでいた)

## Test plan
- [x] `refinePose.recoversFromPerturbedPose`: 摂動を加えた初期姿勢から8点立方体で精度 1e-6 で復元
- [x] `refinePose.worksWithFourPoints`: 4点でも正しく復元
- [x] `refinePose.onePointTranslation`: 1点 + tx,ty DOF で平行移動を追従
- [x] `refinePose.twoPointsScaleAndRotation`: 2点 + wz,tx,ty,tz DOF で再投影誤差が十分小さい
- [x] ブラウザで single_view ページの動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)